### PR TITLE
[FEATURE] Determine gerritProject from gitWebUrl if not given

### DIFF
--- a/check-changes.php
+++ b/check-changes.php
@@ -139,6 +139,10 @@ foreach ($projectsToCheck as $project => $projectData) {
 	$gerritIssues = array();
 	if (isset($projectData['gerritProject'])) {
 		$gerritIssues = fetchGerritReviewRequests($projectData['gerritProject']);
+	} else {
+		$urlParts = parse_url($projectData['gitWebUrl']);
+		$gerritProject = ltrim(substr($urlParts['path'], 0, -4), '/');
+		$gerritIssues = fetchGerritReviewRequests($gerritProject);
 	}
 	foreach ($releasesToCheck as $releaseRange) {
 		$startCommit = $releaseRange[1];


### PR DESCRIPTION
When a project has no gerritProject set, the script tries to
use the path from the gitWebUrl instead.
