### PR TITLE
[TASK] Suppress all output (except errors)

### DIFF
--- a/check-changes.php
+++ b/check-changes.php
@@ -187,16 +187,16 @@ foreach ($projectsToCheck as $project => $projectData) {
 		}
 		if ($online) {
 			$output = array();
-			exec('GIT_DIR="' . $GIT_DIR . '" git fetch --all --tags', $output, $exitCode);
+			exec('GIT_DIR="' . $GIT_DIR . '" git fetch --quiet --all --tags', $output, $exitCode);
 			if ($exitCode !== 0) {
 				exit($exitCode);
 			}
-			exec('GIT_DIR="' . $GIT_DIR . '" git reset --hard ' . $branch, $output, $exitCode);
+			exec('GIT_DIR="' . $GIT_DIR . '" git reset --quiet --hard ' . $branch, $output, $exitCode);
 			if ($exitCode !== 0) {
 				exit($exitCode);
 			}
 			$output = array();
-			exec('GIT_DIR="' . $GIT_DIR . '" git submodule update --init');
+			exec('GIT_DIR="' . $GIT_DIR . '" git submodule --quiet update --init');
 		}
 
 		$lastHash[$branch] = '';


### PR DESCRIPTION
Suppress output by default. This is very useful when running as a cron  job (actually it's already used in production on tools.typo3.org, I just didn't push the change back so far...)
